### PR TITLE
feat: inject setting and QPS providers

### DIFF
--- a/src/Abp.Captcha.Domain/IP/IPManager.cs
+++ b/src/Abp.Captcha.Domain/IP/IPManager.cs
@@ -20,9 +20,15 @@ namespace MagicalConch.Abp.Captcha.IP
         private readonly IIPQPSRestrictionsProvider _ipQpsRestrictionsProvider;
         private readonly IDistributedCache<IPVisitCache> _ipVisitCache;
 
-        public IPManager(IIPRepository ipRepository, IDistributedCache<IPVisitCache> ipVisitCache)
+        public IPManager(
+            IIPRepository ipRepository,
+            ISettingProvider settingProvider,
+            IIPQPSRestrictionsProvider ipQpsRestrictionsProvider,
+            IDistributedCache<IPVisitCache> ipVisitCache)
         {
             _ipRepository = ipRepository;
+            _settingProvider = settingProvider;
+            _ipQpsRestrictionsProvider = ipQpsRestrictionsProvider;
             _ipVisitCache = ipVisitCache;
         }
 


### PR DESCRIPTION
## Summary
- inject ISettingProvider and IIPQPSRestrictionsProvider into IPManager
- ensure providers are available for dependency injection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68998ed8969c8328a8b1f0dd7b7eda49